### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -13,17 +13,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Go
-        uses: actions/setup-go@v6.4.0
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: 1.23
 
-      - uses: actions/checkout@v6.0.2
-
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: setup git access to private repos
         run: git config --global url."https://${TOKEN}:x-oauth-basic@github.com/sprintertech/".insteadOf "https://github.com/sprintertech/"
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v9.2.0
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
           args: --timeout=10m
           only-new-issues: true

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -13,17 +13,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@v6.4.0
         with:
           go-version: 1.23
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
 
       - name: setup git access to private repos
         run: git config --global url."https://${TOKEN}:x-oauth-basic@github.com/sprintertech/".insteadOf "https://github.com/sprintertech/"
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@v9.2.0
         with:
           args: --timeout=10m
           only-new-issues: true

--- a/.github/workflows/deploy-portainer-staging.yml
+++ b/.github/workflows/deploy-portainer-staging.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
         with:
           clean: true
 

--- a/.github/workflows/deploy-portainer-staging.yml
+++ b/.github/workflows/deploy-portainer-staging.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           clean: true
 

--- a/.github/workflows/mocks.yml
+++ b/.github/workflows/mocks.yml
@@ -13,12 +13,11 @@ jobs:
   mocks-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
-
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: setup git access to private repos
         run: git config --global url."https://${TOKEN}:x-oauth-basic@github.com/sprintertech/".insteadOf "https://github.com/sprintertech/"
 
-      - uses: actions/setup-go@v6.4.0
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "^1.23"
 

--- a/.github/workflows/mocks.yml
+++ b/.github/workflows/mocks.yml
@@ -13,12 +13,12 @@ jobs:
   mocks-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6.0.2
 
       - name: setup git access to private repos
         run: git config --global url."https://${TOKEN}:x-oauth-basic@github.com/sprintertech/".insteadOf "https://github.com/sprintertech/"
 
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v6.4.0
         with:
           go-version: "^1.23"
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,7 +9,7 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v4
+      - uses: amannn/action-semantic-pull-request@v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,7 +9,7 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v6.1.1
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -17,9 +17,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6.0.2
 
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v6.4.0
         with:
           go-version: '1.23'
 
@@ -27,32 +27,32 @@ jobs:
         run: make build-all
 
       - name: Archive Linux 64
-        uses: thedoctor0/zip-release@master
+        uses: thedoctor0/zip-release@0.7.6
         with:
           filename: 'relayer-linux-amd64.zip'
           directory: 'build/linux-amd64/'
 
       - name: Archive Linux Arm
-        uses: thedoctor0/zip-release@master
+        uses: thedoctor0/zip-release@0.7.6
         with:
           filename: 'relayer-linux-arm.zip'
           directory: 'build/linux-arm/'
 
       - name: Archive Darwin 64
-        uses: thedoctor0/zip-release@master
+        uses: thedoctor0/zip-release@0.7.6
         with:
           filename: 'relayer-darwin-amd64.zip'
           directory: 'build/darwin-amd64/'
 
       - name: Archive Darwin Arm 64
-        uses: thedoctor0/zip-release@master
+        uses: thedoctor0/zip-release@0.7.6
         with:
           filename: 'relayer-darwin-arm64.zip'
           directory: 'build/darwin-arm64/'
 
       - name: Upload Linux amd64
         id: relayer-linux-amd64
-        uses: AButler/upload-release-assets@v2.0
+        uses: AButler/upload-release-assets@v3.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -61,7 +61,7 @@ jobs:
 
       - name: Upload Linux arm
         id: relayer-linux-arm
-        uses: AButler/upload-release-assets@v2.0
+        uses: AButler/upload-release-assets@v3.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -70,7 +70,7 @@ jobs:
 
       - name: Upload Darwin amd64
         id: relayer-darwin-amd64
-        uses: AButler/upload-release-assets@v2.0
+        uses: AButler/upload-release-assets@v3.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -79,7 +79,7 @@ jobs:
 
       - name: Upload Darwin arm
         id: relayer-darwin-arm64
-        uses: AButler/upload-release-assets@v2.0
+        uses: AButler/upload-release-assets@v3.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -17,9 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.2
-
-      - uses: actions/setup-go@v6.4.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.23'
 
@@ -27,32 +26,32 @@ jobs:
         run: make build-all
 
       - name: Archive Linux 64
-        uses: thedoctor0/zip-release@0.7.6
+        uses: thedoctor0/zip-release@b57d897cb5d60cb78b51a507f63fa184cfe35554 # 0.7.6
         with:
           filename: 'relayer-linux-amd64.zip'
           directory: 'build/linux-amd64/'
 
       - name: Archive Linux Arm
-        uses: thedoctor0/zip-release@0.7.6
+        uses: thedoctor0/zip-release@b57d897cb5d60cb78b51a507f63fa184cfe35554 # 0.7.6
         with:
           filename: 'relayer-linux-arm.zip'
           directory: 'build/linux-arm/'
 
       - name: Archive Darwin 64
-        uses: thedoctor0/zip-release@0.7.6
+        uses: thedoctor0/zip-release@b57d897cb5d60cb78b51a507f63fa184cfe35554 # 0.7.6
         with:
           filename: 'relayer-darwin-amd64.zip'
           directory: 'build/darwin-amd64/'
 
       - name: Archive Darwin Arm 64
-        uses: thedoctor0/zip-release@0.7.6
+        uses: thedoctor0/zip-release@b57d897cb5d60cb78b51a507f63fa184cfe35554 # 0.7.6
         with:
           filename: 'relayer-darwin-arm64.zip'
           directory: 'build/darwin-arm64/'
 
       - name: Upload Linux amd64
         id: relayer-linux-amd64
-        uses: AButler/upload-release-assets@v3.0
+        uses: AButler/upload-release-assets@3d6774fae0ed91407dc5ae29d576b166536d1777 # v3.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -61,7 +60,7 @@ jobs:
 
       - name: Upload Linux arm
         id: relayer-linux-arm
-        uses: AButler/upload-release-assets@v3.0
+        uses: AButler/upload-release-assets@3d6774fae0ed91407dc5ae29d576b166536d1777 # v3.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -70,7 +69,7 @@ jobs:
 
       - name: Upload Darwin amd64
         id: relayer-darwin-amd64
-        uses: AButler/upload-release-assets@v3.0
+        uses: AButler/upload-release-assets@3d6774fae0ed91407dc5ae29d576b166536d1777 # v3.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -79,7 +78,7 @@ jobs:
 
       - name: Upload Darwin arm
         id: relayer-darwin-arm64
-        uses: AButler/upload-release-assets@v3.0
+        uses: AButler/upload-release-assets@3d6774fae0ed91407dc5ae29d576b166536d1777 # v3.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/publish-latest.yml
+++ b/.github/workflows/publish-latest.yml
@@ -22,15 +22,14 @@ jobs:
     steps:
       # Checkout the repository
       - name: Checkout code
-        uses: actions/checkout@v6.0.2
-
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: setup git access to private repos
         run: git config --global url."https://${TOKEN}:x-oauth-basic@github.com/sprintertech/".insteadOf "https://github.com/sprintertech/"
 
       # Log in to GHCR
       - name: Log in to GHCR
         id: ghcr
-        uses: docker/login-action@v4.0.0
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -39,7 +38,7 @@ jobs:
 
       # Build and push the Docker image
       - name: Build and push Docker image
-        uses: docker/build-push-action@v7.0.0
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
           context: .
           push: true

--- a/.github/workflows/publish-latest.yml
+++ b/.github/workflows/publish-latest.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       # Checkout the repository
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: setup git access to private repos
         run: git config --global url."https://${TOKEN}:x-oauth-basic@github.com/sprintertech/".insteadOf "https://github.com/sprintertech/"
@@ -30,7 +30,7 @@ jobs:
       # Log in to GHCR
       - name: Log in to GHCR
         id: ghcr
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4.0.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -39,7 +39,7 @@ jobs:
 
       # Build and push the Docker image
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7.0.0
         with:
           context: .
           push: true

--- a/.github/workflows/publish-tagged.yml
+++ b/.github/workflows/publish-tagged.yml
@@ -23,15 +23,14 @@ jobs:
     steps:
       # Checkout the repository
       - name: Checkout code
-        uses: actions/checkout@v6.0.2
-
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: setup git access to private repos
         run: git config --global url."https://${TOKEN}:x-oauth-basic@github.com/sprintertech/".insteadOf "https://github.com/sprintertech/"
 
       # Log in to GHCR
       - name: Log in to GHCR
         id: ghcr
-        uses: docker/login-action@v4.0.0
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -40,7 +39,7 @@ jobs:
 
       # Build and push the Docker image
       - name: Build and push Docker image
-        uses: docker/build-push-action@v7.0.0
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
           context: .
           push: true

--- a/.github/workflows/publish-tagged.yml
+++ b/.github/workflows/publish-tagged.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       # Checkout the repository
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: setup git access to private repos
         run: git config --global url."https://${TOKEN}:x-oauth-basic@github.com/sprintertech/".insteadOf "https://github.com/sprintertech/"
@@ -31,7 +31,7 @@ jobs:
       # Log in to GHCR
       - name: Log in to GHCR
         id: ghcr
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4.0.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -40,7 +40,7 @@ jobs:
 
       # Build and push the Docker image
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7.0.0
         with:
           context: .
           push: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,8 +14,8 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
 
-      - uses: actions/checkout@v2
-      - uses: google-github-actions/release-please-action@v3
+      - uses: actions/checkout@v6.0.2
+      - uses: google-github-actions/release-please-action@v4.1.1
         id: release
         with:
           token: ${{ secrets.RELEASE_PLEASE_PAT }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,8 +14,8 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
 
-      - uses: actions/checkout@v6.0.2
-      - uses: google-github-actions/release-please-action@v4.1.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: google-github-actions/release-please-action@e4dc86ba9405554aeba3c6bb2d169500e7d3b4ee # v4.1.1
         id: release
         with:
           token: ${{ secrets.RELEASE_PLEASE_PAT }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,16 +24,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@v6.4.0
         with:
           go-version: ${{ matrix.go-version }}
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6.0.2
       - id: go-cache-paths
         run: |
           echo "GO_BUILD=$(go env GOCACHE)" >> "$GITHUB_OUTPUT"
           echo "GO_MOD=$(go env GOMODCACHE)" >> "$GITHUB_OUTPUT"
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5.0.4
         with:
           path: |
             ${{ steps.go-cache-paths.outputs.GO_BUILD }}
@@ -48,7 +48,7 @@ jobs:
       - name: Cover
         run:  echo "COVER=$(go tool cover -func cover.out | grep total | awk '{print substr($3, 1, length($3)-1)}')" >> $GITHUB_ENV
       - name: Create comment
-        uses: peter-evans/create-or-update-comment@v1
+        uses: peter-evans/create-or-update-comment@v5.0.0
         with:
           issue-number: ${{github.event.number}}
           body: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,16 +24,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Go
-        uses: actions/setup-go@v6.4.0
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ matrix.go-version }}
       - name: Checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - id: go-cache-paths
         run: |
           echo "GO_BUILD=$(go env GOCACHE)" >> "$GITHUB_OUTPUT"
           echo "GO_MOD=$(go env GOMODCACHE)" >> "$GITHUB_OUTPUT"
-      - uses: actions/cache@v5.0.4
+      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: |
             ${{ steps.go-cache-paths.outputs.GO_BUILD }}
@@ -48,7 +48,7 @@ jobs:
       - name: Cover
         run:  echo "COVER=$(go tool cover -func cover.out | grep total | awk '{print substr($3, 1, length($3)-1)}')" >> $GITHUB_ENV
       - name: Create comment
-        uses: peter-evans/create-or-update-comment@v5.0.0
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           issue-number: ${{github.event.number}}
           body: |


### PR DESCRIPTION
## Summary
- Pin all GitHub Action references to immutable commit SHAs instead of mutable tags
- Prevents supply chain attacks via tag poisoning (e.g. Trivy-style attacks)
- Version comments preserved inline for auditability
- Actions updated to latest versions where applicable

## Format
```yaml
# Before (mutable tag):
uses: actions/checkout@v6.0.2
# After (immutable SHA):
uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
```

## Test plan
- [ ] Verify CI passes with SHA-pinned actions