### PR TITLE
fix: scale input amount

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -253,6 +253,7 @@ func Run() error {
 					)
 					acrossMh := evmMessage.NewAcrossMessageHandler(
 						*c.GeneralChainConfig.Id,
+						tokenStore,
 						acrossPools,
 						repayerAddresses,
 						coordinator,

--- a/chains/evm/message/across.go
+++ b/chains/evm/message/across.go
@@ -13,9 +13,11 @@ import (
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/rs/zerolog/log"
+	"github.com/sprintertech/sprinter-signing/chains"
 	"github.com/sprintertech/sprinter-signing/chains/evm/calls/events"
 	"github.com/sprintertech/sprinter-signing/chains/evm/signature"
 	"github.com/sprintertech/sprinter-signing/comm"
+	"github.com/sprintertech/sprinter-signing/config"
 	"github.com/sprintertech/sprinter-signing/tss"
 	"github.com/sprintertech/sprinter-signing/tss/ecdsa/signing"
 	"github.com/sygmaprotocol/sygma-core/relayer/message"
@@ -55,7 +57,8 @@ type DepositFetcher interface {
 }
 
 type AcrossMessageHandler struct {
-	chainID uint64
+	chainID    uint64
+	tokenStore config.TokenStore
 
 	pools               map[uint64]common.Address
 	repayers            map[uint64]common.Address
@@ -72,6 +75,7 @@ type AcrossMessageHandler struct {
 
 func NewAcrossMessageHandler(
 	chainID uint64,
+	tokenStore config.TokenStore,
 	pools map[uint64]common.Address,
 	repayers map[uint64]common.Address,
 	coordinator Coordinator,
@@ -84,6 +88,7 @@ func NewAcrossMessageHandler(
 ) *AcrossMessageHandler {
 	return &AcrossMessageHandler{
 		chainID:             chainID,
+		tokenStore:          tokenStore,
 		pools:               pools,
 		repayers:            repayers,
 		coordinator:         coordinator,
@@ -123,7 +128,36 @@ func (h *AcrossMessageHandler) HandleMessage(m *message.Message) (*proposal.Prop
 		return nil, err
 	}
 
-	if data.BorrowAmount.Cmp(d.InputAmount) > 0 {
+	sourceTokenAddress := common.BytesToAddress(d.InputToken[:])
+	symbol, srcToken, err := h.tokenStore.ConfigByAddress(h.chainID, sourceTokenAddress)
+	if err != nil {
+		err = fmt.Errorf(
+			"failed to get source token for address %s on chain %d: %w",
+			sourceTokenAddress.Hex(),
+			h.chainID,
+			err,
+		)
+		data.ErrChn <- err
+		return nil, err
+	}
+
+	destToken, err := h.tokenStore.ConfigBySymbol(
+		d.DestinationChainId.Uint64(),
+		symbol,
+	)
+	if err != nil {
+		err = fmt.Errorf(
+			"failed to get destination token by symbol %s on chain %d: %w",
+			symbol,
+			d.DestinationChainId.Uint64(),
+			err,
+		)
+		data.ErrChn <- err
+		return nil, err
+	}
+
+	scaledInputAmount := chains.ScaleTokenAmount(d.InputAmount, int64(srcToken.Decimals), int64(destToken.Decimals))
+	if data.BorrowAmount.Cmp(scaledInputAmount) > 0 {
 		err := fmt.Errorf("borrow amount exceeds input amount")
 		data.ErrChn <- err
 		return nil, err
@@ -133,7 +167,7 @@ func (h *AcrossMessageHandler) HandleMessage(m *message.Message) (*proposal.Prop
 		context.Background(),
 		h.chainID,
 		data.DepositTxHash,
-		common.BytesToAddress(d.InputToken[12:]),
+		sourceTokenAddress,
 		d.InputAmount)
 	if err != nil {
 		data.ErrChn <- err
@@ -151,7 +185,7 @@ func (h *AcrossMessageHandler) HandleMessage(m *message.Message) (*proposal.Prop
 	unlockHash, err := signature.BorrowUnlockHash(
 		calldata,
 		data.BorrowAmount,
-		common.BytesToAddress(d.OutputToken[12:]),
+		common.BytesToAddress(d.OutputToken[:]),
 		d.DestinationChainId,
 		h.pools[d.DestinationChainId.Uint64()],
 		data.Deadline,

--- a/chains/evm/message/across_test.go
+++ b/chains/evm/message/across_test.go
@@ -13,10 +13,10 @@ import (
 	"github.com/sprintertech/sprinter-signing/chains/evm/calls/events"
 	"github.com/sprintertech/sprinter-signing/chains/evm/message"
 	mock_message "github.com/sprintertech/sprinter-signing/chains/evm/message/mock"
-	"github.com/sprintertech/sprinter-signing/config"
 	"github.com/sprintertech/sprinter-signing/comm"
 	mock_communication "github.com/sprintertech/sprinter-signing/comm/mock"
 	mock_host "github.com/sprintertech/sprinter-signing/comm/p2p/mock/host"
+	"github.com/sprintertech/sprinter-signing/config"
 	"github.com/sprintertech/sprinter-signing/keyshare"
 	mock_tss "github.com/sprintertech/sprinter-signing/tss/ecdsa/common/mock"
 	"github.com/stretchr/testify/suite"
@@ -80,11 +80,11 @@ func (s *AcrossMessageHandlerTestSuite) SetupTest() {
 	// Ethereum: 0x93a9d5e32f5c81cbd17ceb842edc65002e3a79da4efbdc9f1e1f7e97fbcd669b
 	s.validLog, _ = hex.DecodeString("000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc200000000000000000000000082af49447d8a07e3bd95bd0d56f35241523fbab100000000000000000000000000000000000000000000000000119baee0ab0400000000000000000000000000000000000000000000000000001199073ea3008d0000000000000000000000000000000000000000000000000000000067bc6e3f0000000000000000000000000000000000000000000000000000000067bc927b00000000000000000000000000000000000000000000000000000000000000000000000000000000000000001886a1eb051c10f20c7386576a6a0716b20b2734000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001400000000000000000000000000000000000000000000000000000000000000000")
 
-	// Addresses derived the same way the handler does: common.BytesToAddress(token[12:])
+	// Addresses derived the same way the handler does: common.BytesToAddress(token[:])
 	inputToken6Arr := fillBytes32("input_token_address_1234567890")
 	outputToken6Arr := fillBytes32("output_token_address_0987654321")
-	inputToken6Addr := common.BytesToAddress(inputToken6Arr[12:])
-	outputToken6Addr := common.BytesToAddress(outputToken6Arr[12:])
+	inputToken6Addr := common.BytesToAddress(inputToken6Arr[:])
+	outputToken6Addr := common.BytesToAddress(outputToken6Arr[:])
 	inputToken18Addr := common.HexToAddress("0x1111111111111111111111111111111111111111")
 	outputToken18to6Addr := common.HexToAddress("0x2222222222222222222222222222222222222222")
 

--- a/chains/evm/message/across_test.go
+++ b/chains/evm/message/across_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sprintertech/sprinter-signing/chains/evm/calls/events"
 	"github.com/sprintertech/sprinter-signing/chains/evm/message"
 	mock_message "github.com/sprintertech/sprinter-signing/chains/evm/message/mock"
+	"github.com/sprintertech/sprinter-signing/config"
 	"github.com/sprintertech/sprinter-signing/comm"
 	mock_communication "github.com/sprintertech/sprinter-signing/comm/mock"
 	mock_host "github.com/sprintertech/sprinter-signing/comm/p2p/mock/host"
@@ -79,12 +80,30 @@ func (s *AcrossMessageHandlerTestSuite) SetupTest() {
 	// Ethereum: 0x93a9d5e32f5c81cbd17ceb842edc65002e3a79da4efbdc9f1e1f7e97fbcd669b
 	s.validLog, _ = hex.DecodeString("000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc200000000000000000000000082af49447d8a07e3bd95bd0d56f35241523fbab100000000000000000000000000000000000000000000000000119baee0ab0400000000000000000000000000000000000000000000000000001199073ea3008d0000000000000000000000000000000000000000000000000000000067bc6e3f0000000000000000000000000000000000000000000000000000000067bc927b00000000000000000000000000000000000000000000000000000000000000000000000000000000000000001886a1eb051c10f20c7386576a6a0716b20b2734000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001400000000000000000000000000000000000000000000000000000000000000000")
 
-	confirmations := make(map[uint64]uint64)
-	confirmations[1000] = 100
-	confirmations[2000] = 200
+	// Addresses derived the same way the handler does: common.BytesToAddress(token[12:])
+	inputToken6Arr := fillBytes32("input_token_address_1234567890")
+	outputToken6Arr := fillBytes32("output_token_address_0987654321")
+	inputToken6Addr := common.BytesToAddress(inputToken6Arr[12:])
+	outputToken6Addr := common.BytesToAddress(outputToken6Arr[12:])
+	inputToken18Addr := common.HexToAddress("0x1111111111111111111111111111111111111111")
+	outputToken18to6Addr := common.HexToAddress("0x2222222222222222222222222222222222222222")
+
+	tokenStore := config.TokenStore{
+		Tokens: map[uint64]map[string]config.TokenConfig{
+			1: {
+				"USDC":  {Address: inputToken6Addr, Decimals: 6},
+				"WUSDC": {Address: inputToken18Addr, Decimals: 18},
+			},
+			137: {
+				"USDC":  {Address: outputToken6Addr, Decimals: 6},
+				"WUSDC": {Address: outputToken18to6Addr, Decimals: 6},
+			},
+		},
+	}
 
 	s.handler = message.NewAcrossMessageHandler(
 		1,
+		tokenStore,
 		pools,
 		repayers,
 		s.mockCoordinator,
@@ -269,4 +288,65 @@ func (s *AcrossMessageHandlerTestSuite) Test_HandleMessage_ValidDeposit() {
 
 	err = <-errChn
 	s.Nil(err)
+}
+
+func (s *AcrossMessageHandlerTestSuite) Test_HandleMessage_BorrowAmountExceedsScaledInputAmount() {
+	s.mockCommunication.EXPECT().Broadcast(
+		gomock.Any(),
+		gomock.Any(),
+		comm.AcrossMsg,
+		fmt.Sprintf("%d-%s", 1, comm.AcrossSessionID),
+	).Return(nil)
+	p, _ := pstoremem.NewPeerstore()
+	s.mockHost.EXPECT().Peerstore().Return(p)
+
+	// WUSDC on src chain has 18 decimals, on dst chain has 6 decimals.
+	// InputAmount of 1e18 (1 token at 18 dec) scales to 1e6 (1 token at 6 dec).
+	// BorrowAmount of 1e6+1 must be rejected.
+	var inputToken18Arr [32]byte
+	copy(inputToken18Arr[12:], common.HexToAddress("0x1111111111111111111111111111111111111111").Bytes())
+
+	deposit := &events.AcrossDeposit{
+		InputToken:         inputToken18Arr,
+		OutputToken:        fillBytes32("output_token_address_0987654321"),
+		InputAmount:        new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil), // 1e18
+		OutputAmount:       big.NewInt(990000),
+		DestinationChainId: big.NewInt(137),
+		DepositId:          big.NewInt(123456789),
+		//nolint:gosec
+		QuoteTimestamp: uint32(time.Now().Unix()),
+		//nolint:gosec
+		ExclusivityDeadline: uint32(time.Now().Add(10 * time.Minute).Unix()),
+		//nolint:gosec
+		FillDeadline:     uint32(time.Now().Add(1 * time.Hour).Unix()),
+		Depositor:        fillBytes32("depositor_address_abcdef123456"),
+		Recipient:        fillBytes32("recipient_address_654321fedcba"),
+		ExclusiveRelayer: fillBytes32("relayer_address_112233445566"),
+		Message:          []byte("Sample message for AcrossDeposit"),
+	}
+	s.mockDepositFetcher.EXPECT().Deposit(gomock.Any(), gomock.Any(), gomock.Any()).Return(deposit, nil)
+
+	errChn := make(chan error, 1)
+	ad := &message.AcrossData{
+		ErrChn:           errChn,
+		DepositId:        big.NewInt(2595221),
+		Nonce:            big.NewInt(101),
+		BorrowAmount:     big.NewInt(1_000_001), // 1e6 + 1, exceeds scaled amount of 1e6
+		LiquidityPool:    common.HexToAddress("0xbe526bA5d1ad94cC59D7A79d99A59F607d31A657"),
+		Caller:           common.HexToAddress("0x5ECF7351930e4A251193aA022Ef06249C6cBfa27"),
+		RepaymentChainID: 10,
+	}
+	m := &coreMessage.Message{
+		Data:        ad,
+		Source:      1,
+		Destination: 2,
+	}
+
+	prop, err := s.handler.HandleMessage(m)
+
+	s.Nil(prop)
+	s.ErrorContains(err, "borrow amount exceeds input amount")
+
+	err = <-errChn
+	s.ErrorContains(err, "borrow amount exceeds input amount")
 }

--- a/chains/evm/message/lifiEscrow.go
+++ b/chains/evm/message/lifiEscrow.go
@@ -12,6 +12,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/rs/zerolog/log"
+	"github.com/sprintertech/sprinter-signing/chains"
 	"github.com/sprintertech/sprinter-signing/chains/evm/calls/consts"
 	"github.com/sprintertech/sprinter-signing/chains/evm/signature"
 	"github.com/sprintertech/sprinter-signing/comm"
@@ -262,7 +263,17 @@ func (h *LifiEscrowMessageHandler) verifyOrder(order *lifi.LifiOrder, borrowAmou
 		return fmt.Errorf("orders with multiple outputs not supported")
 	}
 
-	if order.GenericInputs[0].Amount.Cmp(borrowAmount) == -1 {
+	tokenIn := common.BytesToAddress(order.GenericInputs[0].TokenAddress[:])
+	symbol, srcToken, err := h.tokenStore.ConfigByAddress(h.chainID, tokenIn)
+	if err != nil {
+		return err
+	}
+	dstToken, err := h.tokenStore.ConfigBySymbol(order.Order.Outputs[0].ChainID, symbol)
+	if err != nil {
+		return err
+	}
+	scaledInputAmount := chains.ScaleTokenAmount(order.GenericInputs[0].Amount, int64(srcToken.Decimals), int64(dstToken.Decimals))
+	if scaledInputAmount.Cmp(borrowAmount) == -1 {
 		return fmt.Errorf("order input is less than requested borrow amount")
 	}
 

--- a/chains/util.go
+++ b/chains/util.go
@@ -24,7 +24,7 @@ func CalculateStartingBlock(startBlock *big.Int, blockConfirmations *big.Int) (*
 // When src < dst: exponent is negative, so effectively multiplies.
 func ScaleTokenAmount(amount *big.Int, srcDecimals, dstDecimals int64) *big.Int {
 	if srcDecimals == dstDecimals {
-		return amount
+		return new(big.Int).Set(amount)
 	}
 	if srcDecimals > dstDecimals {
 		scale := new(big.Int).Exp(big.NewInt(10), big.NewInt(srcDecimals-dstDecimals), nil)

--- a/chains/util.go
+++ b/chains/util.go
@@ -17,3 +17,19 @@ func CalculateStartingBlock(startBlock *big.Int, blockConfirmations *big.Int) (*
 	startBlock.Sub(startBlock, mod)
 	return startBlock, nil
 }
+
+// ScaleTokenAmount scales amount from srcDecimals to dstDecimals.
+// Formula: amount / 10^(srcDecimals-dstDecimals)
+// When src > dst (e.g. BSC USDC 18 -> Base USDC 6): divides by 10^12.
+// When src < dst: exponent is negative, so effectively multiplies.
+func ScaleTokenAmount(amount *big.Int, srcDecimals, dstDecimals int64) *big.Int {
+	if srcDecimals == dstDecimals {
+		return amount
+	}
+	if srcDecimals > dstDecimals {
+		scale := new(big.Int).Exp(big.NewInt(10), big.NewInt(srcDecimals-dstDecimals), nil)
+		return new(big.Int).Div(amount, scale)
+	}
+	scale := new(big.Int).Exp(big.NewInt(10), big.NewInt(dstDecimals-srcDecimals), nil)
+	return new(big.Int).Mul(amount, scale)
+}

--- a/chains/util_test.go
+++ b/chains/util_test.go
@@ -35,3 +35,42 @@ func (s *UtilTestSuite) Test_CalculateStartingBlock_Nil() {
 	s.Nil(res)
 	s.NotNil(err)
 }
+
+func (s *UtilTestSuite) TestScaleTokenAmount() {
+	tests := []struct {
+		name        string
+		amount      *big.Int
+		srcDecimals int64
+		dstDecimals int64
+		want        *big.Int
+	}{
+		{
+			name:        "same decimals — no scaling",
+			amount:      big.NewInt(1_000_000),
+			srcDecimals: 6,
+			dstDecimals: 6,
+			want:        big.NewInt(1_000_000),
+		},
+		{
+			name:        "18 to 6 decimals",
+			amount:      big.NewInt(1_000_000_000_000_000_000),
+			srcDecimals: 18,
+			dstDecimals: 6,
+			want:        big.NewInt(1_000_000),
+		},
+		{
+			name:        "6 to 18 decimals",
+			amount:      big.NewInt(1_000_000),
+			srcDecimals: 6,
+			dstDecimals: 18,
+			want:        big.NewInt(1_000_000_000_000_000_000),
+		},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			got := ScaleTokenAmount(tt.amount, tt.srcDecimals, tt.dstDecimals)
+			s.Equal(tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
In case of different decimals for input and output token, we need to properly scale input amount. Fixes made for across and lifi, similar edge case errors exist on mayan and rhinestone but didn't bother resolving them as they're not used. 
Please double check could this break something else or are there more cases of this that I might've missed.

## Description
<!--- Describe your changes in detail -->

## Related Issue Or Context
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Otherwise, describe context and motivation for change herre -->

Closes: #<issue>

## How Has This Been Tested? Testing details.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have ensured that all acceptance criteria (or expected behavior) from issue are met
- [ ] I have updated the documentation locally and in docs.
- [ ] I have added tests to cover my changes.
- [ ] I have ensured that all the checks are passing and green, I've signed the CLA bot
