### PR TITLE
feat: instrument mpc signing phase durations

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -121,7 +121,7 @@ func Run() error {
 	sygmaMetrics, err := metrics.NewSprinterMetrics(ctx, mp.Meter("relayer-metric-provider"), configuration.RelayerConfig.Env, configuration.RelayerConfig.Id, Version)
 	panicOnError(err)
 
-	communication := p2p.NewCommunication(host, "p2p/sprinter")
+	communication := p2p.NewCommunication(host, "p2p/sprinter", sygmaMetrics)
 	electorFactory := elector.NewCoordinatorElectorFactory(host, configuration.RelayerConfig.BullyConfig)
 	coordinator := tss.NewCoordinator(host, communication, sygmaMetrics, electorFactory)
 

--- a/comm/communication_test.go
+++ b/comm/communication_test.go
@@ -228,6 +228,7 @@ func InitializeHostsAndCommunications(numberOfActors uint16, protocolID protocol
 		com := p2p.NewCommunication(
 			testHosts[i],
 			protocolID,
+			p2p.NoopMetrics{},
 		)
 		testCommunications = append(testCommunications, com)
 	}

--- a/comm/elector/elector.go
+++ b/comm/elector/elector.go
@@ -36,7 +36,7 @@ type CoordinatorElectorFactory struct {
 
 // NewCoordinatorElectorFactory creates new CoordinatorElectorFactory
 func NewCoordinatorElectorFactory(h host.Host, config relayer.BullyConfig) *CoordinatorElectorFactory {
-	communication := p2p.NewCommunication(h, ProtocolID)
+	communication := p2p.NewCommunication(h, ProtocolID, p2p.NoopMetrics{})
 
 	return &CoordinatorElectorFactory{
 		h:      h,

--- a/comm/p2p/libp2p.go
+++ b/comm/p2p/libp2p.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/network"
@@ -24,20 +25,38 @@ const (
 	defaultBufferSize = 20480
 )
 
+// Metrics records timing for outbound libp2p sends. The concrete implementation
+// lives in the metrics package; NoopMetrics is provided here for callers that
+// do not need telemetry (health check comms, tests).
+type Metrics interface {
+	RecordCommSend(peer string, d time.Duration)
+	RecordCommDnsResolve(d time.Duration)
+}
+
+type NoopMetrics struct{}
+
+func (NoopMetrics) RecordCommSend(peer string, d time.Duration) {}
+func (NoopMetrics) RecordCommDnsResolve(d time.Duration)        {}
+
 type Libp2pCommunication struct {
 	SessionSubscriptionManager
 	h             host.Host
 	logger        zerolog.Logger
 	streamManager *StreamManager
+	metrics       Metrics
 }
 
-func NewCommunication(h host.Host, protocolID protocol.ID) Libp2pCommunication {
+func NewCommunication(h host.Host, protocolID protocol.ID, metrics Metrics) Libp2pCommunication {
+	if metrics == nil {
+		metrics = NoopMetrics{}
+	}
 	logger := log.With().Str("Module", "communication").Str("Peer", h.ID().String()).Logger()
 	c := Libp2pCommunication{
 		SessionSubscriptionManager: NewSessionSubscriptionManager(),
 		h:                          h,
 		logger:                     logger,
 		streamManager:              NewStreamManager(h, protocolID),
+		metrics:                    metrics,
 	}
 
 	// start processing incoming messages
@@ -169,6 +188,11 @@ func (c Libp2pCommunication) sendMessage(
 	msgType comm.MessageType,
 	sessionID string,
 ) error {
+	sendStart := time.Now()
+	defer func() {
+		c.metrics.RecordCommSend(to.String(), time.Since(sendStart))
+	}()
+
 	err := c.resolveDNS(to)
 	if err != nil {
 		return err
@@ -198,6 +222,11 @@ func (c Libp2pCommunication) sendMessage(
 }
 
 func (c Libp2pCommunication) resolveDNS(peerID peer.ID) error {
+	resolveStart := time.Now()
+	defer func() {
+		c.metrics.RecordCommDnsResolve(time.Since(resolveStart))
+	}()
+
 	pi := c.h.Peerstore().PeerInfo(peerID)
 	resolver, err := madns.NewResolver()
 	if err != nil {

--- a/comm/p2p/libp2p_test.go
+++ b/comm/p2p/libp2p_test.go
@@ -47,7 +47,7 @@ func (s *Libp2pCommunicationTestSuite) SetupTest() {
 func (s *Libp2pCommunicationTestSuite) TestLibp2pCommunication_MessageProcessing_ValidMessage() {
 	s.mockHost.EXPECT().ID().Return(s.allowedPeers[0])
 	s.mockHost.EXPECT().SetStreamHandler(s.testProtocolID, gomock.Any()).Return()
-	c := p2p.NewCommunication(s.mockHost, s.testProtocolID)
+	c := p2p.NewCommunication(s.mockHost, s.testProtocolID, p2p.NoopMetrics{})
 
 	msgChannel := make(chan *comm.WrappedMessage)
 	c.Subscribe("1", comm.CoordinatorPingMsg, msgChannel)
@@ -87,7 +87,7 @@ func (s *Libp2pCommunicationTestSuite) TestLibp2pCommunication_MessageProcessing
 func (s *Libp2pCommunicationTestSuite) TestLibp2pCommunication_StreamHandlerFunction_ValidMessageWithSubscribers() {
 	s.mockHost.EXPECT().ID().Return(s.allowedPeers[0])
 	s.mockHost.EXPECT().SetStreamHandler(s.testProtocolID, gomock.Any()).Return()
-	c := p2p.NewCommunication(s.mockHost, s.testProtocolID)
+	c := p2p.NewCommunication(s.mockHost, s.testProtocolID, p2p.NoopMetrics{})
 
 	testWrappedMsg := comm.WrappedMessage{
 		MessageType: comm.CoordinatorPingMsg,
@@ -165,7 +165,7 @@ func (s *Libp2pCommunicationTestSuite) TestLibp2pCommunication_SendReceiveMessag
 		connectionGate := p2p.NewConnectionGate(topology)
 		newHost, _ := p2p.NewHost(privateKeys[i], topology, connectionGate, 4000+portOffset+i)
 		testHosts = append(testHosts, newHost)
-		communications = append(communications, p2p.NewCommunication(newHost, protocol.ID(protocolID)))
+		communications = append(communications, p2p.NewCommunication(newHost, protocol.ID(protocolID), p2p.NoopMetrics{}))
 	}
 
 	msgChn := make(chan *comm.WrappedMessage)

--- a/jobs/jobs.go
+++ b/jobs/jobs.go
@@ -18,7 +18,7 @@ type RelayerStatusMeter interface {
 }
 
 func StartCommunicationHealthCheckJob(h host.Host, interval time.Duration, metrics RelayerStatusMeter) {
-	healthComm := p2p.NewCommunication(h, "p2p/health")
+	healthComm := p2p.NewCommunication(h, "p2p/health", p2p.NoopMetrics{})
 	for {
 		time.Sleep(interval)
 		log.Debug().Msg("Starting communication health check")

--- a/metrics/mpc.go
+++ b/metrics/mpc.go
@@ -21,12 +21,12 @@ type MpcMetrics struct {
 	totalRelayerCount      *int64
 	availableRelayerCount  *int64
 
-	sessionTimeHistogram         metric.Float64Histogram
-	initiateTimeHistogram        metric.Float64Histogram
-	commSendTimeHistogram        metric.Float64Histogram
-	commDnsResolveTimeHistogram  metric.Float64Histogram
-	sessionStartTimeCache        *ttlcache.Cache[string, time.Time]
-	opts                         metric.MeasurementOption
+	sessionTimeHistogram        metric.Float64Histogram
+	initiateTimeHistogram       metric.Float64Histogram
+	commSendTimeHistogram       metric.Float64Histogram
+	commDnsResolveTimeHistogram metric.Float64Histogram
+	sessionStartTimeCache       *ttlcache.Cache[string, time.Time]
+	opts                        metric.MeasurementOption
 }
 
 // NewMpcMetrics initializes metrics related to the MPC set

--- a/metrics/mpc.go
+++ b/metrics/mpc.go
@@ -7,6 +7,7 @@ import (
 	"github.com/jellydator/ttlcache/v3"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/rs/zerolog/log"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 )
 
@@ -20,8 +21,12 @@ type MpcMetrics struct {
 	totalRelayerCount      *int64
 	availableRelayerCount  *int64
 
-	sessionTimeHistogram  metric.Float64Histogram
-	sessionStartTimeCache *ttlcache.Cache[string, time.Time]
+	sessionTimeHistogram         metric.Float64Histogram
+	initiateTimeHistogram        metric.Float64Histogram
+	commSendTimeHistogram        metric.Float64Histogram
+	commDnsResolveTimeHistogram  metric.Float64Histogram
+	sessionStartTimeCache        *ttlcache.Cache[string, time.Time]
+	opts                         metric.MeasurementOption
 }
 
 // NewMpcMetrics initializes metrics related to the MPC set
@@ -56,15 +61,43 @@ func NewMpcMetrics(ctx context.Context, meter metric.Meter, opts metric.Measurem
 		return nil, err
 	}
 
+	initiateTimeHistogram, err := meter.Float64Histogram(
+		"relayer.InitiateTime",
+		metric.WithDescription("Duration (seconds) of the coordinator initiate handshake: broadcast -> threshold+1 peers ready"),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	commSendTimeHistogram, err := meter.Float64Histogram(
+		"relayer.CommSendTime",
+		metric.WithDescription("Duration (seconds) of a single outbound libp2p message send, labelled by target peer"),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	commDnsResolveTimeHistogram, err := meter.Float64Histogram(
+		"relayer.CommDnsResolveTime",
+		metric.WithDescription("Duration (seconds) of DNS resolution + libp2p Connect per outbound send"),
+	)
+	if err != nil {
+		return nil, err
+	}
+
 	return &MpcMetrics{
-		totalRelayersGauge:     totalRelayersGauge,
-		availableRelayersGauge: availableRelayersGauge,
-		totalRelayerCount:      totalRelayerCount,
-		availableRelayerCount:  availableRelayerCount,
-		sessionTimeHistogram:   sessionTimeHistogram,
+		totalRelayersGauge:          totalRelayersGauge,
+		availableRelayersGauge:      availableRelayersGauge,
+		totalRelayerCount:           totalRelayerCount,
+		availableRelayerCount:       availableRelayerCount,
+		sessionTimeHistogram:        sessionTimeHistogram,
+		initiateTimeHistogram:       initiateTimeHistogram,
+		commSendTimeHistogram:       commSendTimeHistogram,
+		commDnsResolveTimeHistogram: commDnsResolveTimeHistogram,
 		sessionStartTimeCache: ttlcache.New(
 			ttlcache.WithTTL[string, time.Time](SESSION_TTL),
 		),
+		opts: opts,
 	}, nil
 }
 
@@ -84,5 +117,22 @@ func (m *MpcMetrics) EndProcess(sessionID string) {
 		return
 	}
 
-	m.sessionTimeHistogram.Record(context.Background(), time.Since(startTime.Value()).Seconds())
+	m.sessionTimeHistogram.Record(context.Background(), time.Since(startTime.Value()).Seconds(), m.opts)
+}
+
+func (m *MpcMetrics) RecordInitiateDuration(d time.Duration) {
+	m.initiateTimeHistogram.Record(context.Background(), d.Seconds(), m.opts)
+}
+
+func (m *MpcMetrics) RecordCommSend(peerID string, d time.Duration) {
+	m.commSendTimeHistogram.Record(
+		context.Background(),
+		d.Seconds(),
+		m.opts,
+		metric.WithAttributes(attribute.String("peer", peerID)),
+	)
+}
+
+func (m *MpcMetrics) RecordCommDnsResolve(d time.Duration) {
+	m.commDnsResolveTimeHistogram.Record(context.Background(), d.Seconds(), m.opts)
 }

--- a/tss/coordinator.go
+++ b/tss/coordinator.go
@@ -39,6 +39,7 @@ type TssProcess interface {
 type Metrics interface {
 	StartProcess(sessionID string)
 	EndProcess(sessionID string)
+	RecordInitiateDuration(d time.Duration)
 }
 
 type Coordinator struct {
@@ -210,6 +211,7 @@ func (c *Coordinator) initiate(
 
 	ticker := time.NewTicker(c.InitiatePeriod)
 	defer ticker.Stop()
+	initiateStart := time.Now()
 	c.broadcastInitiateMsg(tssProcess.SessionID())
 	for {
 		select {
@@ -236,6 +238,7 @@ func (c *Coordinator) initiate(
 				}
 
 				_ = c.communication.Broadcast(c.host.Peerstore().Peers(), startMsgBytes, comm.TssStartMsg, tssProcess.SessionID())
+				c.metrics.RecordInitiateDuration(time.Since(initiateStart))
 				ticker.Stop()
 				go c.startProcess(ctx, tssProcess, true, startParams, resultChn, errChn)
 			}

--- a/tss/ecdsa/keygen/keygen_test.go
+++ b/tss/ecdsa/keygen/keygen_test.go
@@ -50,7 +50,7 @@ func (s *KeygenTestSuite) Test_ValidKeygenProcess() {
 	s.MockECDSAStorer.EXPECT().UnlockKeyshare().Times(3)
 	s.MockECDSAStorer.EXPECT().StoreKeyshare(gomock.Any()).Times(3)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
 	pool := pool.New().WithContext(ctx)

--- a/tss/mock/coordinator.go
+++ b/tss/mock/coordinator.go
@@ -189,6 +189,18 @@ func (mr *MockMetricsMockRecorder) EndProcess(sessionID any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EndProcess", reflect.TypeOf((*MockMetrics)(nil).EndProcess), sessionID)
 }
 
+// RecordInitiateDuration mocks base method.
+func (m *MockMetrics) RecordInitiateDuration(d time.Duration) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "RecordInitiateDuration", d)
+}
+
+// RecordInitiateDuration indicates an expected call of RecordInitiateDuration.
+func (mr *MockMetricsMockRecorder) RecordInitiateDuration(d any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecordInitiateDuration", reflect.TypeOf((*MockMetrics)(nil).RecordInitiateDuration), d)
+}
+
 // StartProcess mocks base method.
 func (m *MockMetrics) StartProcess(sessionID string) {
 	m.ctrl.T.Helper()

--- a/tss/test/utils.go
+++ b/tss/test/utils.go
@@ -42,6 +42,7 @@ func (s *CoordinatorTestSuite) SetupTest() {
 	s.MockTssProcess = mock_tss.NewMockTssProcess(s.GomockController)
 	s.MockMetrics = mock_tss.NewMockMetrics(s.GomockController)
 	s.MockMetrics.EXPECT().StartProcess(gomock.Any()).AnyTimes()
+	s.MockMetrics.EXPECT().RecordInitiateDuration(gomock.Any()).AnyTimes()
 	s.PartyNumber = 3
 	s.Threshold = 1
 


### PR DESCRIPTION
We can revert this later, but Im putting this up to try and really understand where some of the bottlenecks are coming from. 

## Summary

Instruments the signing path with phase-level OTel histograms so we can measure where time is spent before applying any optimizations. No behavior changes.

Motivation: signing rounds reportedly take 2-3s. We already have `relayer.SessionTime` (full session duration), but there's no breakdown by phase or visibility into libp2p send cost. This PR adds that breakdown so the next PRs (DNS caching, broadcast error handling, keccak fix, etc.) can be validated numerically.

## New metrics

All are `Float64Histogram`s in seconds, emitted via the existing `MpcMetrics` / OTel collector pipeline.

### `relayer.InitiateTime`
Duration of the coordinator handshake: from when the coordinator broadcasts `TssInitiateMsg` to the moment enough `TssReadyMsg` replies arrive to satisfy threshold+1 (i.e. right before the coordinator broadcasts `TssStartMsg`). Only emitted on the elected coordinator. Recorded in `tss/coordinator.go:initiate`.

Read it as: _how long the pre-TSS rendezvous took._ If this is large, the bottleneck is peer readiness / re-broadcast latency (including the 1s `initiatePeriod` rebroadcast fallback), not the MPC crypto itself.

### `relayer.CommSendTime`
Wall-clock duration of a single outbound libp2p message send in `Libp2pCommunication.sendMessage`: DNS resolve + stream acquisition + `bufio.NewWriterSize` + `WriteStream` + `Flush`. Labelled by target peer (`peer` attribute) so you can spot one slow remote.

Read it as: _total per-message send cost._ Multiply by the number of messages per signing session to see how much of `SessionTime` is spent in comm.

### `relayer.CommDnsResolveTime`
Duration of `Libp2pCommunication.resolveDNS`: `madns.NewResolver()` + `resolver.Resolve` + `host.Connect`. Called once per outbound `sendMessage`, unconditionally.

Read it as: _overhead we pay per message for DNS + redundant Connect._ This is the biggest suspected hotspot - the resolver is recreated every call and `Connect` is invoked even when the peer is already connected. If this histogram dominates `CommSendTime`, Phase 1 DNS caching is the right next step.

### Derived views (no new metric)
- `CommSendTime - CommDnsResolveTime` per peer: pure stream write cost
- `SessionTime - InitiateTime`: TSS crypto + result distribution time (non-coordinator peers only record `SessionTime`, since they never enter `initiate`)

## Wiring

`Libp2pCommunication` now takes a local `Metrics` interface:

- `app/app.go` passes `sygmaMetrics` (`*SprinterMetrics` embeds `*MpcMetrics` which satisfies the interface)
- `jobs/jobs.go` (health check) and `comm/elector/elector.go` (coordinator election) pass `p2p.NoopMetrics{}` - these comms are not on the signing hot path
- Tests use `p2p.NoopMetrics{}`
- `tss.Metrics` interface grew `RecordInitiateDuration(d time.Duration)`; mock regenerated; `CoordinatorTestSuite.SetupTest` expects it with `AnyTimes()`

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./comm/p2p/... ./comm/elector/... ./tss/... ./metrics/...\` all pass
- [ ] Deploy to staging, run a signing round, confirm the three new histograms show up in Grafana
- [ ] Capture p50/p95 baseline for each histogram as reference numbers for the Phase 1 optimization PR
- [ ] One pre-existing unrelated failure: \`comm/subID_test.go:32\` (nanosecond collision in \`NewSubscriptionID\` under macOS timer resolution) - fails on unmodified main too; out of scope here

## Notes for reviewers

- No logic changes, only \`defer record\` wrappers and the interface plumbing. Behavior is identical on the NoopMetrics path.
- Follow-up PR will apply the actual optimizations (cache \`madns.NewResolver\`, skip \`h.Connect\` when already connected, bounded \`Connect\` context, non-fatal broadcast errors, remove dead keccak hash in peer sort). Baseline histograms from this PR are the gate for that work.