### PR TITLE
fix: stop NewSubscriptionID from colliding

### DIFF
--- a/comm/subID.go
+++ b/comm/subID.go
@@ -8,15 +8,21 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	"time"
+	"sync/atomic"
 )
 
 // SubscriptionID is unique identifier for each subscription
 // It is defined as: SessionID-MessageType-SubscriptionIdentifier
 type SubscriptionID string
 
+// subIDCounter provides monotonic uniqueness for subscription IDs without
+// relying on clock resolution. Earlier implementation used time.Now().UnixNano()
+// which collides on coarse-resolution clocks (e.g. macOS, where consecutive
+// calls in a tight loop often return the same nanosecond).
+var subIDCounter atomic.Uint64
+
 func NewSubscriptionID(sessionID string, msgType MessageType) SubscriptionID {
-	return SubscriptionID(fmt.Sprintf("%s-%d-%d", sessionID, msgType, time.Now().UnixNano()))
+	return SubscriptionID(fmt.Sprintf("%s-%d-%d", sessionID, msgType, subIDCounter.Add(1)))
 }
 
 func (sID SubscriptionID) SessionID() string {


### PR DESCRIPTION
Might not matter unless doing local dev without docker. 

## Summary

\`NewSubscriptionID\` relies on \`time.Now().UnixNano()\` for uniqueness. On macOS and other coarse-resolution clocks, consecutive calls in a tight loop return the same timestamp, so two subscription IDs collide. This is visible as a persistent failure of \`TestSubscriptionID_UniqueIDs\` (\`comm/subID_test.go:32\`) on local runs and any CI image with a lower-resolution monotonic clock.

Swap the nanosecond timestamp for a process-local \`atomic.Uint64\` counter. Monotonic, lock-free, and immune to clock resolution.

## Why not UUIDs?

The identifier segment is an opaque string to every consumer (\`Unwrap\` splits on \`-\` and returns \`subIDParts[2]\` as a string without parsing). A counter keeps the existing format, stays compact, and needs no new dep.

## Test plan

- [x] \`go test ./comm -run TestRunSubscriptionIDTestSuite -count=20\` passes (previously flaked within the first few runs)
- [x] Existing \`Unwrap\` tests still pass — format is unchanged
- [ ] Full test job green on CI

## Notes

- Subscription IDs are process-local; the counter resets on restart. No persisted consumers rely on their absolute value.