### PR TITLE
feat: label SessionTime histogram by process type

### DIFF
--- a/metrics/mpc.go
+++ b/metrics/mpc.go
@@ -7,6 +7,7 @@ import (
 	"github.com/jellydator/ttlcache/v3"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/rs/zerolog/log"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 )
 
@@ -14,14 +15,20 @@ const (
 	SESSION_TTL = time.Minute * 10
 )
 
+type sessionStart struct {
+	at          time.Time
+	processType string
+}
+
 type MpcMetrics struct {
 	totalRelayersGauge     metric.Int64ObservableGauge
 	availableRelayersGauge metric.Int64ObservableGauge
 	totalRelayerCount      *int64
 	availableRelayerCount  *int64
 
-	sessionTimeHistogram  metric.Float64Histogram
-	sessionStartTimeCache *ttlcache.Cache[string, time.Time]
+	sessionTimeHistogram metric.Float64Histogram
+	sessionStartCache    *ttlcache.Cache[string, sessionStart]
+	opts                 metric.MeasurementOption
 }
 
 // NewMpcMetrics initializes metrics related to the MPC set
@@ -51,7 +58,10 @@ func NewMpcMetrics(ctx context.Context, meter metric.Meter, opts metric.Measurem
 		return nil, err
 	}
 
-	sessionTimeHistogram, err := meter.Float64Histogram("relayer.SessionTime")
+	sessionTimeHistogram, err := meter.Float64Histogram(
+		"relayer.SessionTime",
+		metric.WithDescription("Duration (seconds) of a TSS process, labelled by process type (keygen/signing/resharing)"),
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -62,9 +72,10 @@ func NewMpcMetrics(ctx context.Context, meter metric.Meter, opts metric.Measurem
 		totalRelayerCount:      totalRelayerCount,
 		availableRelayerCount:  availableRelayerCount,
 		sessionTimeHistogram:   sessionTimeHistogram,
-		sessionStartTimeCache: ttlcache.New(
-			ttlcache.WithTTL[string, time.Time](SESSION_TTL),
+		sessionStartCache: ttlcache.New(
+			ttlcache.WithTTL[string, sessionStart](SESSION_TTL),
 		),
+		opts: opts,
 	}, nil
 }
 
@@ -73,16 +84,26 @@ func (m *MpcMetrics) TrackRelayerStatus(unavailable peer.IDSlice, all peer.IDSli
 	*m.availableRelayerCount = int64(len(all) - len(unavailable))
 }
 
-func (m *MpcMetrics) StartProcess(sessionID string) {
-	m.sessionStartTimeCache.Set(sessionID, time.Now(), ttlcache.DefaultTTL)
+func (m *MpcMetrics) StartProcess(sessionID, processType string) {
+	m.sessionStartCache.Set(
+		sessionID,
+		sessionStart{at: time.Now(), processType: processType},
+		ttlcache.DefaultTTL,
+	)
 }
 
 func (m *MpcMetrics) EndProcess(sessionID string) {
-	startTime := m.sessionStartTimeCache.Get(sessionID)
-	if startTime == nil {
+	entry := m.sessionStartCache.Get(sessionID)
+	if entry == nil {
 		log.Warn().Msgf("Session start time with ID %s not found", sessionID)
 		return
 	}
 
-	m.sessionTimeHistogram.Record(context.Background(), time.Since(startTime.Value()).Seconds())
+	start := entry.Value()
+	m.sessionTimeHistogram.Record(
+		context.Background(),
+		time.Since(start.at).Seconds(),
+		m.opts,
+		metric.WithAttributes(attribute.String("type", start.processType)),
+	)
 }

--- a/tss/coordinator.go
+++ b/tss/coordinator.go
@@ -32,12 +32,13 @@ type TssProcess interface {
 	Retryable() bool
 	StartParams(readyPeers []peer.ID) []byte
 	SessionID() string
+	Type() string
 	ValidCoordinators() []peer.ID
 	Timeout() time.Duration
 }
 
 type Metrics interface {
-	StartProcess(sessionID string)
+	StartProcess(sessionID, processType string)
 	EndProcess(sessionID string)
 }
 
@@ -88,7 +89,7 @@ func (c *Coordinator) Execute(ctx context.Context, tssProcesses []TssProcess, re
 	}
 	c.pendingProcesses[sessionID] = true
 	c.processLock.Unlock()
-	c.metrics.StartProcess(sessionID)
+	c.metrics.StartProcess(sessionID, process.Type())
 
 	ctx, cancel := context.WithCancel(ctx)
 	p := pool.New().WithContext(ctx).WithCancelOnError()

--- a/tss/ecdsa/keygen/keygen.go
+++ b/tss/ecdsa/keygen/keygen.go
@@ -172,3 +172,7 @@ func (k *Keygen) processEndMessage(ctx context.Context, endChn chan keygen.Local
 func (k *Keygen) Retryable() bool {
 	return false
 }
+
+func (k *Keygen) Type() string {
+	return "keygen"
+}

--- a/tss/ecdsa/resharing/resharing.go
+++ b/tss/ecdsa/resharing/resharing.go
@@ -265,3 +265,7 @@ func (r *Resharing) sortParties(parties tss.SortedPartyIDs, oldParties tss.Sorte
 func (r *Resharing) Retryable() bool {
 	return false
 }
+
+func (r *Resharing) Type() string {
+	return "resharing"
+}

--- a/tss/ecdsa/signing/signing.go
+++ b/tss/ecdsa/signing/signing.go
@@ -259,6 +259,10 @@ func (s *Signing) Retryable() bool {
 	return true
 }
 
+func (s *Signing) Type() string {
+	return "signing"
+}
+
 // monitorSigning checks if the process is stuck and waiting for peers and sends an error
 // if it is
 func (s *Signing) monitorSigning(ctx context.Context) error {

--- a/tss/mock/coordinator.go
+++ b/tss/mock/coordinator.go
@@ -139,6 +139,20 @@ func (mr *MockTssProcessMockRecorder) Timeout() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Timeout", reflect.TypeOf((*MockTssProcess)(nil).Timeout))
 }
 
+// Type mocks base method.
+func (m *MockTssProcess) Type() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Type")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// Type indicates an expected call of Type.
+func (mr *MockTssProcessMockRecorder) Type() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Type", reflect.TypeOf((*MockTssProcess)(nil).Type))
+}
+
 // ValidCoordinators mocks base method.
 func (m *MockTssProcess) ValidCoordinators() []peer.ID {
 	m.ctrl.T.Helper()
@@ -190,13 +204,13 @@ func (mr *MockMetricsMockRecorder) EndProcess(sessionID any) *gomock.Call {
 }
 
 // StartProcess mocks base method.
-func (m *MockMetrics) StartProcess(sessionID string) {
+func (m *MockMetrics) StartProcess(sessionID, processType string) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "StartProcess", sessionID)
+	m.ctrl.Call(m, "StartProcess", sessionID, processType)
 }
 
 // StartProcess indicates an expected call of StartProcess.
-func (mr *MockMetricsMockRecorder) StartProcess(sessionID any) *gomock.Call {
+func (mr *MockMetricsMockRecorder) StartProcess(sessionID, processType any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartProcess", reflect.TypeOf((*MockMetrics)(nil).StartProcess), sessionID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartProcess", reflect.TypeOf((*MockMetrics)(nil).StartProcess), sessionID, processType)
 }

--- a/tss/test/utils.go
+++ b/tss/test/utils.go
@@ -41,7 +41,7 @@ func (s *CoordinatorTestSuite) SetupTest() {
 	s.MockCommunication = mock_comm.NewMockCommunication(s.GomockController)
 	s.MockTssProcess = mock_tss.NewMockTssProcess(s.GomockController)
 	s.MockMetrics = mock_tss.NewMockMetrics(s.GomockController)
-	s.MockMetrics.EXPECT().StartProcess(gomock.Any()).AnyTimes()
+	s.MockMetrics.EXPECT().StartProcess(gomock.Any(), gomock.Any()).AnyTimes()
 	s.PartyNumber = 3
 	s.Threshold = 1
 


### PR DESCRIPTION
## Summary

\`relayer.SessionTime\` has always lumped all three TSS workloads into one distribution, which makes its quantiles meaningless:

| Workload   | Typical duration | Dominant cost |
|------------|------------------|---------------|
| Keygen     | tens of seconds  | Paillier key generation |
| Signing    | hundreds of ms   | CMP rounds + libp2p     |
| Resharing  | seconds          | reshared key derivation |

Any dashboard p50/p95 computed over this histogram is a weighted average of three wildly different curves.

## Change

- Added \`Type() string\` to \`TssProcess\` (returns \`"keygen"\`, \`"signing"\`, \`"resharing"\`)
- Widened \`Metrics.StartProcess\` to \`StartProcess(sessionID, processType string)\`
- \`MpcMetrics\` now stores \`{at, processType}\` per session and emits the \`type\` attribute on \`SessionTime.Record\`
- Regenerated coordinator mock; updated \`CoordinatorTestSuite.SetupTest\` expectation

No change to cache.Metrics or the \`EndProcess\` signature - the type is recovered from the stored session entry.

## Grafana note

After this lands, query p95 as:

\`\`\`
histogram_quantile(0.95, sum by (le) (rate(relayer_SessionTime_bucket{type="signing"}[5m])))
\`\`\`

Dashboards that don't filter on \`type\` will silently aggregate all three workloads, same as today.

## Test plan

- [x] \`go build ./...\` clean
- [x] Go tests in affected packages pass locally
- [ ] CI green
- [ ] Staging: confirm \`SessionTime\` metric shows \`type\` label in the collector

## Notes for reviewers

- \`EndProcess\` only emits the type present at \`StartProcess\`. If you ever call \`EndProcess\` for a session we didn't start, the emit is skipped (existing warning path).
- Process types are plain strings rather than a typed enum to keep cardinality obvious and avoid a cross-package dep for consumers.