### PR TITLE
feat: declare seconds unit on duration histograms

### DIFF
--- a/metrics/mpc.go
+++ b/metrics/mpc.go
@@ -56,7 +56,10 @@ func NewMpcMetrics(ctx context.Context, meter metric.Meter, opts metric.Measurem
 		return nil, err
 	}
 
-	sessionTimeHistogram, err := meter.Float64Histogram("relayer.SessionTime")
+	sessionTimeHistogram, err := meter.Float64Histogram(
+		"relayer.SessionTime",
+		metric.WithUnit("s"),
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -64,6 +67,7 @@ func NewMpcMetrics(ctx context.Context, meter metric.Meter, opts metric.Measurem
 	initiateTimeHistogram, err := meter.Float64Histogram(
 		"relayer.InitiateTime",
 		metric.WithDescription("Duration (seconds) of the coordinator initiate handshake: broadcast -> threshold+1 peers ready"),
+		metric.WithUnit("s"),
 	)
 	if err != nil {
 		return nil, err
@@ -72,6 +76,7 @@ func NewMpcMetrics(ctx context.Context, meter metric.Meter, opts metric.Measurem
 	commSendTimeHistogram, err := meter.Float64Histogram(
 		"relayer.CommSendTime",
 		metric.WithDescription("Duration (seconds) of a single outbound libp2p message send, labelled by target peer"),
+		metric.WithUnit("s"),
 	)
 	if err != nil {
 		return nil, err
@@ -80,6 +85,7 @@ func NewMpcMetrics(ctx context.Context, meter metric.Meter, opts metric.Measurem
 	commDnsResolveTimeHistogram, err := meter.Float64Histogram(
 		"relayer.CommDnsResolveTime",
 		metric.WithDescription("Duration (seconds) of DNS resolution + libp2p Connect per outbound send"),
+		metric.WithUnit("s"),
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

Adds `metric.WithUnit("s")` to the four `Float64Histogram`s in `MpcMetrics`:

- `relayer.SessionTime` (PR #143)
- `relayer.InitiateTime` (PR #171)
- `relayer.CommSendTime` (PR #171)
- `relayer.CommDnsResolveTime` (PR #171)

## Why

`sygma-core` registers a sub-second bucket view in `observability.InitMetricProvider`:

```go
// observability/metrics.go (initSecondView)
sdkmetric.NewView(
    sdkmetric.Instrument{Unit: "s"},
    sdkmetric.Stream{Aggregation: aggregation.ExplicitBucketHistogram{
        Boundaries: []float64{1e-6, 1e-5, 1e-4, 1e-3, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 5, 10, 100, 1000, 10000},
    }},
)
```

The view is keyed by `Instrument{Unit: "s"}`. The histograms in `metrics/mpc.go` declared a description but no unit, so the view never matched and the SDK fell back to OTel's default histogram boundaries `[5, 10, 25, 50, ..., 10000]` — which are tuned for milliseconds. Signing-phase durations (sub-second to a few seconds) collapse into the `le=5` bucket, making `histogram_quantile` return values pinned to bucket boundaries rather than real percentiles.

Values are already recorded in seconds via `d.Seconds()`, so no math changes — only bucketing.

## Grafana query change

The OTLP→Prometheus exporter appends a `_seconds` suffix when the instrument carries `Unit: "s"`. After this PR, dashboard queries change:

| Before | After |
|---|---|
| `relayer_SessionTime_bucket` | `relayer_SessionTime_seconds_bucket` |
| `relayer_InitiateTime_bucket` | `relayer_InitiateTime_seconds_bucket` |
| `relayer_CommSendTime_bucket` | `relayer_CommSendTime_seconds_bucket` |
| `relayer_CommDnsResolveTime_bucket` | `relayer_CommDnsResolveTime_seconds_bucket` |

In practice no dashboards depend on the old names yet — the OTel collector URL was only wired into staging in #174, so historical data is empty.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./metrics/... ./tss/... ./comm/p2p/...` pass
- [ ] After deploy, confirm `relayer_SessionTime_seconds_count` and the three new `_seconds_count` series are non-empty in Grafana
- [ ] Confirm `histogram_quantile(0.95, ...)` returns values that vary with workload rather than snapping to bucket boundaries