### PR TITLE
feat: surface OpenTelemetry export errors and config

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -61,6 +61,10 @@ import (
 	"github.com/sygmaprotocol/sygma-core/relayer/message"
 	"github.com/sygmaprotocol/sygma-core/store"
 	"github.com/sygmaprotocol/sygma-core/store/lvldb"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/noop"
 )
 
 var Version string
@@ -111,13 +115,25 @@ func Run() error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	mp, err := observability.InitMetricProvider(context.Background(), configuration.RelayerConfig.OpenTelemetryCollectorURL)
-	panicOnError(err)
-	defer func() {
-		if err := mp.Shutdown(context.Background()); err != nil {
-			log.Error().Msgf("Error shutting down meter provider: %v", err)
-		}
-	}()
+	otel.SetErrorHandler(otel.ErrorHandlerFunc(func(err error) {
+		log.Error().Err(err).Msg("OpenTelemetry SDK error")
+	}))
+
+	var mp metric.MeterProvider
+	if url := configuration.RelayerConfig.OpenTelemetryCollectorURL; url == "" {
+		log.Warn().Msg("OpenTelemetry disabled: collector URL not configured")
+		mp = noop.NewMeterProvider()
+	} else {
+		log.Info().Str("url", url).Msg("Initializing OpenTelemetry metric provider")
+		sdkMp, err := observability.InitMetricProvider(context.Background(), url)
+		panicOnError(err)
+		defer func() {
+			if err := sdkMp.Shutdown(context.Background()); err != nil {
+				log.Error().Msgf("Error shutting down meter provider: %v", err)
+			}
+		}()
+		mp = sdkMp
+	}
 	sygmaMetrics, err := metrics.NewSprinterMetrics(ctx, mp.Meter("relayer-metric-provider"), configuration.RelayerConfig.Env, configuration.RelayerConfig.Id, Version)
 	panicOnError(err)
 


### PR DESCRIPTION
## Summary

Three small additions to `app.Run` that turn silent OTLP failures into observable startup signals.

```go
otel.SetErrorHandler(otel.ErrorHandlerFunc(func(err error) {
    log.Error().Err(err).Msg("OpenTelemetry SDK error")
}))

var mp metric.MeterProvider
if url := configuration.RelayerConfig.OpenTelemetryCollectorURL; url == "" {
    log.Warn().Msg("OpenTelemetry disabled: collector URL not configured")
    mp = noop.NewMeterProvider()
} else {
    log.Info().Str("url", url).Msg("Initializing OpenTelemetry metric provider")
    sdkMp, err := observability.InitMetricProvider(context.Background(), url)
    panicOnError(err)
    defer func() { /* shutdown */ }()
    mp = sdkMp
}
```

## Why

Investigating "metrics not appearing in Grafana" today required guessing because the relayer prints nothing about telemetry at startup. Three sharp edges combined into one black box:

### 1. The OTel SDK silently swallows export errors

The metric SDK uses a global error handler. When none is registered, export failures (connection refused, TLS handshake, 404 on wrong path, context deadline exceeded) are dropped. Registering a handler that routes errors through zerolog makes container logs the source of truth.

### 2. The configured URL is invisible

Container logs say nothing about the OTel target. There is no way from logs to tell whether `OpenTelemetryCollectorURL` is empty, malformed, or pointing at an unreachable host. A single INFO log on startup fixes this.

### 3. An empty URL silently exports to localhost

`InitMetricProvider` calls `url.Parse(agentURL)`, which returns no error for `""`. `otlpmetrichttp.WithEndpoint("")` then falls back to the OTLP HTTP default of `localhost:4318`. The relayer starts up clean and ships metrics into a void. Treating the empty case as "telemetry disabled" with a `noop.MeterProvider` and a WARN log makes misconfiguration loud while keeping local-dev simple (no collector required).

## Behavior change

- **OTel collector URL set correctly:** no behavior change. Same provider, same exporter, same metrics. New: one INFO log at startup, one WARN never fires, the error handler is silent unless the SDK reports a problem.
- **OTel collector URL empty:** previously exported to `localhost:4318`. Now uses `noop.NewMeterProvider()`, which has zero overhead and emits a single WARN at startup.
- **OTel collector URL malformed or unreachable:** previously silent. Now every export attempt logs an ERROR with the underlying SDK error.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./app/...` clean
- [ ] Deploy to staging, confirm an INFO log on startup shows the configured collector URL
- [ ] If the URL is wrong, confirm SDK errors now appear in container logs
- [ ] Local dev without `SYG_RELAYER_OPENTELEMETRYCOLLECTORURL`: confirm WARN logs and the relayer runs cleanly with no metric export attempts

## Related

Pairs with #177 (declare seconds unit on duration histograms) which fixes the bucket-view mismatch for the same set of histograms. Together they make the staging metrics pipeline both observable from logs and meaningful in Grafana.